### PR TITLE
Bump version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pkg/
 .project
 .eclipse.buildship.core.prefs
 release/wi-kubernetes-manifests.yaml
+/kind

--- a/src/otelcollector/Dockerfile
+++ b/src/otelcollector/Dockerfile
@@ -1,4 +1,4 @@
-FROM otel/opentelemetry-collector:0.42.0
+FROM otel/opentelemetry-collector-contrib:0.43.0
 COPY conf.yml .
 EXPOSE 1888
 EXPOSE 8888


### PR DESCRIPTION
### Change Summary
OpenTelemetry collector updated from 0.42 to 0.43.
Also changed from default collector to contrib version
