### PR TITLE
Removed duplicated logrus.Logger

### DIFF
--- a/src/frontend/main.go
+++ b/src/frontend/main.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
@@ -45,22 +44,6 @@ const (
 	cookieSessionID = cookiePrefix + "session-id"
 	cookieCurrency  = cookiePrefix + "currency"
 )
-
-var log *logrus.Logger
-
-func init() {
-	log = logrus.New()
-	log.Level = logrus.DebugLevel
-	log.Formatter = &logrus.JSONFormatter{
-		FieldMap: logrus.FieldMap{
-			logrus.FieldKeyTime:  "timestamp",
-			logrus.FieldKeyLevel: "severity",
-			logrus.FieldKeyMsg:   "message",
-		},
-		TimestampFormat: time.RFC3339Nano,
-	}
-	log.Out = os.Stdout
-}
 
 var (
 	whitelistedCurrencies = map[string]bool{


### PR DESCRIPTION
### Background 
`src/frontend/main.go` and `src/frontend/deployment_details.go` had the function `init()` to initialize the `logrus.Logger`.

### Change Summary
Removed the `init()` from src/frontend/main.go 