### PR TITLE
Bump versions and add trace logs

### DIFF
--- a/src/adservice/Dockerfile
+++ b/src/adservice/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get -y update && apt-get install -qqy \
     wget \
     && rm -rf /var/lib/apt/lists/*
 
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.6 && \
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.7 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe
 

--- a/src/adservice/build.gradle
+++ b/src/adservice/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.google.protobuf' version '0.8.14'
+    id 'com.google.protobuf' version '0.8.18'
     id 'com.github.sherter.google-java-format' version '0.9'
     id 'idea'
     id 'application'
@@ -14,8 +14,8 @@ description = 'Ad Service'
 group = "adservice"
 version = "0.1.0-SNAPSHOT"
 
-def grpcVersion = "1.32.1"
-def jacksonVersion = "2.12.1"
+def grpcVersion = "1.44.1"
+def jacksonVersion = "2.13.1"
 def protocVersion = "3.12.3"
 
 tasks.withType(JavaCompile) {
@@ -32,7 +32,7 @@ dependencies {
     if (speed) {
         implementation fileTree(dir: offlineCompile, include: '*.jar')
     } else {
-        implementation "com.google.api.grpc:proto-google-common-protos:1.18.1",
+        implementation "com.google.api.grpc:proto-google-common-protos:2.7.4",
                 "javax.annotation:javax.annotation-api:1.3.2",
                 "io.grpc:grpc-protobuf:${grpcVersion}",
                 "io.grpc:grpc-stub:${grpcVersion}",
@@ -42,7 +42,7 @@ dependencies {
 
         runtimeOnly "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}",
                 "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}",
-                "io.netty:netty-tcnative-boringssl-static:2.0.34.Final"
+                "io.netty:netty-tcnative-boringssl-static:2.0.49.Final"
     }
 }
 

--- a/src/adservice/src/main/java/hipstershop/AdService.java
+++ b/src/adservice/src/main/java/hipstershop/AdService.java
@@ -25,7 +25,7 @@ import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.StatusRuntimeException;
 import io.grpc.health.v1.HealthCheckResponse.ServingStatus;
-import io.grpc.services.*;
+import io.grpc.protobuf.services.*;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/adservice/src/main/proto/demo.proto
+++ b/src/adservice/src/main/proto/demo.proto
@@ -16,6 +16,8 @@ syntax = "proto3";
 
 package hipstershop;
 
+option go_package = "genproto/hipstershop";
+
 // -----------------Cart service-----------------
 
 service CartService {

--- a/src/adservice/src/main/resources/log4j2.xml
+++ b/src/adservice/src/main/resources/log4j2.xml
@@ -18,10 +18,7 @@
 <Configuration status="WARN">
   <Appenders>
     <Console name="STDOUT" target="SYSTEM_OUT">
-      <JsonLayout compact="true" eventEol="true">
-        <KeyValuePair key="time" value="$${date:yyyy-MM-dd}T$${date:HH:mm:ss.SSS}Z"/>
-     </JsonLayout>
-
+        <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} - %logger{36} - %msg trace_id=%X{trace_id} span_id=%X{span_id} trace_flags=%X{trace_flags} %n"/>
     </Console>
   </Appenders>
   <Loggers>


### PR DESCRIPTION
Bumped versions:
- GRPC_HEALTH_PROBE_VERSION=v0.4.7
- 'com.google.protobuf' version '0.8.18'
- grpcVersion = "1.44.1"
- jacksonVersion = "2.13.1"
- com.google.api.grpc:proto-google-common-protos:2.7.4
- io.netty:netty-tcnative-boringssl-static:2.0.49.Final

And updated `src/adservice/src/main/resources/log4j2.xml` to add trace logs